### PR TITLE
Able to run on plattform different than windows

### DIFF
--- a/_template/bin/nuget
+++ b/_template/bin/nuget
@@ -1,6 +1,6 @@
 host_os = RbConfig::CONFIG['host_os']
 windows = /mswin|msys|mingw|cygwin|bccwin|wince|emc/.match(host_os)
 to_exec = [File.dirname(__FILE__) + "/nuget.exe", ARGV.join(' ')]
-to_exec.insert(0,"mono") if ! windows
+to_exec.insert(0, "mono --runtime=v4.0") if ! windows
 result = system(to_exec.join(' '))
 exit 1 unless result

--- a/_template/bin/nuget
+++ b/_template/bin/nuget
@@ -1,2 +1,6 @@
-result = system(File.dirname(__FILE__) + "/nuget.exe " + ARGV.join(' '))
+host_os = RbConfig::CONFIG['host_os']
+windows = /mswin|msys|mingw|cygwin|bccwin|wince|emc/.match(host_os)
+to_exec = [File.dirname(__FILE__) + "/nuget.exe", ARGV.join(' ')]
+to_exec.insert(0,"mono") if ! windows
+result = system(to_exec.join(' '))
 exit 1 unless result


### PR DESCRIPTION
In order to run on a plattform where a .net exe is not an executable, one need to prefix execution with mono.
