### PR TITLE
Using "Gem.windows?" instead of detecting on raw variable

### DIFF
--- a/_template/bin/nuget
+++ b/_template/bin/nuget
@@ -1,5 +1,4 @@
-host_os = RbConfig::CONFIG['host_os']
-windows = /mswin|msys|mingw|cygwin|bccwin|wince|emc/.match(host_os)
+windows = Gem.win_platform? 
 to_exec = [File.dirname(__FILE__) + "/nuget.exe", ARGV.join(' ')]
 to_exec.insert(0, "mono --runtime=v4.0") if ! windows
 result = system(to_exec.join(' '))


### PR DESCRIPTION
This looks a bit cleaner than 

```
/mswin|msys|mingw|cygwin|bccwin|wince|emc/.match(host_os)
```
